### PR TITLE
Doc(guides): Add guide to configure keyboard language

### DIFF
--- a/guides/README.md
+++ b/guides/README.md
@@ -4,6 +4,7 @@ Use this simple index to navigate the available guides in this directory:
 
 - [Fixing the Caps Lock (Bloq Mayus key) in latin american keyboards in Omarchy](./caps_lock.md)
 - [Setting up the fingerprint reader in Asus Vivobook M3500QA (or similar) in Omarchy](./asus_vivobook_fingerprint_reader.md)
+- [Setting Up Language Switching and Display in Waybar on Omarchy](./switching_language_and_config_waybar.md)
 
 ## Contributing:
 

--- a/guides/switching_language_and_config_waybar.md
+++ b/guides/switching_language_and_config_waybar.md
@@ -4,7 +4,7 @@ This guide walks you through configuring language switching in your Omarchy envi
 
 ####  1. Configure Keyboard Layouts and Language Switch Shortcut
 
-File: `~/.config/hypr/input.conf`
+**File:** `~/.config/hypr/input.conf`
 
 First, we need to tell Hyprland which keyboard layouts you'll use and how to switch between them:
 
@@ -60,7 +60,7 @@ Once created, add it to the visible modules section. Here we place it on the rig
 
 To keep visual consistency with the rest of your modules, adjust its style in Waybar’s CSS file.
 
-File: `~/.config/waybar/style.css`
+**File:** `~/.config/waybar/style.css`
 
 ```css
 #language {

--- a/guides/switching_language_and_config_waybar.md
+++ b/guides/switching_language_and_config_waybar.md
@@ -1,0 +1,80 @@
+### Setting Up Language Switching and Display in Waybar on Omarchy
+
+This guide walks you through configuring language switching in your Omarchy environment (a distro built on Arch Linux), including displaying the current language in the Waybar. The process is simple and will let you easily switch between keyboard layouts using ALT + Space.
+
+####  1. Configure Keyboard Layouts and Language Switch Shortcut
+
+File: `~/.config/hypr/input.conf`
+
+First, we need to tell Hyprland which keyboard layouts you'll use and how to switch between them:
+
+```ini
+# Enable US International and Latin American Spanish
+kb_layout = us,latam
+
+# Apply international variant to the English layout
+kb_variant = intl,
+
+# Set ALT + Space as the shortcut to switch languages
+kb_options = grp:alt_space_toggle
+```
+
+This setup enables you to use both US International (with tilde, ñ, etc.) and Spanish layouts, switching between them with `ALT + Space`.
+
+#### 2. Display the Current Language in Waybar
+
+Now let’s visually integrate this feature into your Waybar, so you always know which layout is active.
+
+**File:** `~/.config/waybar/config.json`
+
+**a. Create the Language Module**
+
+Inside your JSON config, add the following object. This defines the formats to display depending on the active layout:
+
+```json
+"hyprland/language": {
+    "format": "{}",
+    "format-en": "US",
+    "format-en-intl": "US-INTL",
+    "format-es-lat": "ES"
+  }
+```
+
+**b. Register the Module in the Bar**
+
+Once created, add it to the visible modules section. Here we place it on the right side of the bar:
+
+```json
+ "modules-right": [
+    "group/tray-expander",
+    "bluetooth",
+    "network",
+    "pulseaudio",
+    "cpu",
+    "battery",
+    "hyprland/language" // new module
+  ]
+```
+
+#### 3. Style the Language Module
+
+To keep visual consistency with the rest of your modules, adjust its style in Waybar’s CSS file.
+
+File: `~/.config/waybar/style.css`
+
+```css
+#language {
+  min-width: 12px;
+  margin: 0 7.5px;
+}
+```
+
+#### 4. Apply the Changes
+
+Finally, restart Waybar so the changes take effect:
+
+```bash
+pkill waybar && hyprctl dispatch exec waybar
+```
+
+Done! Now you can switch between languages using `ALT + Space` and see which one is currently active right in your Waybar. If something doesn’t display as expected, double-check the layout and variant names, as they may vary depending on your system.


### PR DESCRIPTION
## 🌟  Context

Due to the different layouts and languages that an Alternova user can manage for their keyboard, a tutorial has been added to modify this, including a keyboard shortcut similar to that of other operating systems.

### 🧰 Changes

- **Added** Guide to config the keyboard layout and view in the  Waybar
- **Changed** Main guide to include the keyboard layout guide 